### PR TITLE
Allow Ubuntu 16.04 and correct version number

### DIFF
--- a/manifests/kafka_rest/service.pp
+++ b/manifests/kafka_rest/service.pp
@@ -16,7 +16,7 @@ class confluent::kafka_rest::service (
     ensure  => running,
     enable  => true,
     require => File['/etc/init.d/kafka-rest'],
-    provider => 'init',
+    provider => 'debian',
   }
 
 }

--- a/manifests/kafka_server/service.pp
+++ b/manifests/kafka_server/service.pp
@@ -19,7 +19,7 @@ class confluent::kafka_server::service (
     ensure   => running,
     enable   => true,
     require  => File['/etc/init.d/kafka-server'],
-    provider => 'init',
+    provider => 'debian',
   }
 
 }

--- a/manifests/schema_registry/service.pp
+++ b/manifests/schema_registry/service.pp
@@ -16,7 +16,7 @@ class confluent::schema_registry::service (
     ensure  => running,
     enable  => true,
     require => File['/etc/init.d/kafka-schema_registry'],
-    provider => 'init',
+    provider => 'debian',
   }
 
 }

--- a/manifests/zookeeper/service.pp
+++ b/manifests/zookeeper/service.pp
@@ -19,7 +19,7 @@ class confluent::zookeeper::service (
     ensure   => running,
     enable   => true,
     require  => File['/etc/init.d/zookeeper'],
-    provider => 'init',
+    provider => 'debian',
   }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "finn-confluent",
-  "version": "0.5.1",
+  "version": "0.9.1",
   "author": "finn.no",
   "summary": "Module to install and configure Confluent (Kafka w/zookeeper, Schema Registry, REST proxy)",
   "license": "BSD",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "finn-confluent",
-  "version": "0.5",
+  "version": "0.5.1",
   "author": "finn.no",
   "summary": "Module to install and configure Confluent (Kafka w/zookeeper, Schema Registry, REST proxy)",
   "license": "BSD",


### PR DESCRIPTION
- allows for Ubuntu 16.04 (#1), which does not have provider init
- set version number to latest tag number with semantic versioning (x.x.x)